### PR TITLE
Use `TIME` command in Redis instead of letting the client send the time

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,14 +340,14 @@ Contributions are very welcome. Here's how to get started:
 To publish a new version:
 
 - Update the package version in the `pyproject.toml`
-- Open [Github releases](https://github.com/Feuerstein-Org/steindamm/releases)
+- Open [Github releases](https://github.com/feuerstein-org/steindamm/releases)
 - Press "Draft a new release"
 - Set a tag matching the new version (for example, `v0.8.0`)
 - Set the title matching the tag
 - Add some release notes, explaining what has changed
 - Publish
 
-Once the release is published, our [publish workflow](https://github.com/Feuerstein-Org/steindamm/blob/main/.github/workflows/publish.yaml) should be triggered
+Once the release is published, our [publish workflow](https://github.com/feuerstein-org/steindamm/blob/main/.github/workflows/publish.yaml) should be triggered
 to push the new version to PyPI.
 
 ## Acknowledgment:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,8 +43,8 @@ redis = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/Feuerstein-Org/steindamm"
-Repository = "https://github.com/Feuerstein-Org/steindamm"
+Homepage = "https://github.com/feuerstein-org/steindamm"
+Repository = "https://github.com/feuerstein-org/steindamm"
 
 [dependency-groups]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ requires = ["uv_build>=0.8.5,<0.9.0"]
 build-backend = "uv_build"
 
 [tool.pytest.ini_options]
-addopts = "--allow-hosts=127.0.0.1,::1,10.15.0.2,10.15.0.3,10.15.0.4 --ignore=tests/semaphore/test_sync_semaphore.py --ignore=tests/token_bucket/test_sync_token_bucket.py --ignore=tests/token_bucket/test_token_bucket_factory.py --ignore=tests/token_bucket/test_token_bucket_base.py --ignore=tests/test_redis_cluster.py --ignore=tests/semaphore/test_async_semaphore.py"
+addopts = "--allow-hosts=127.0.0.1,::1,10.15.0.2,10.15.0.3,10.15.0.4"
 asyncio_mode = "auto"
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ requires = ["uv_build>=0.8.5,<0.9.0"]
 build-backend = "uv_build"
 
 [tool.pytest.ini_options]
-addopts = "--allow-hosts=127.0.0.1,::1,10.15.0.2,10.15.0.3,10.15.0.4"
+addopts = "--allow-hosts=127.0.0.1,::1,10.15.0.2,10.15.0.3,10.15.0.4 --ignore=tests/semaphore/test_sync_semaphore.py --ignore=tests/token_bucket/test_sync_token_bucket.py --ignore=tests/token_bucket/test_token_bucket_factory.py --ignore=tests/token_bucket/test_token_bucket_base.py --ignore=tests/test_redis_cluster.py --ignore=tests/semaphore/test_async_semaphore.py"
 asyncio_mode = "auto"
 
 [tool.coverage.run]

--- a/src/steindamm/token_bucket/redis_token_bucket.py
+++ b/src/steindamm/token_bucket/redis_token_bucket.py
@@ -6,7 +6,7 @@ from types import TracebackType
 from typing import ClassVar, cast
 
 from steindamm.base import AsyncLuaScriptBase, SyncLuaScriptBase
-from steindamm.token_bucket.token_bucket_base import TokenBucketBase, get_current_time_ms
+from steindamm.token_bucket.token_bucket_base import TokenBucketBase
 
 
 class SyncRedisTokenBucket(TokenBucketBase, SyncLuaScriptBase):
@@ -39,8 +39,6 @@ class SyncRedisTokenBucket(TokenBucketBase, SyncLuaScriptBase):
 
     def __enter__(self) -> float:
         """Acquire token(s) from the token bucket and sleep until they are available."""
-        # Retrieve timestamp for when to wake up from Redis Lua script
-        milliseconds = get_current_time_ms()
         timestamp: int = cast(
             int,
             self.script(
@@ -50,7 +48,6 @@ class SyncRedisTokenBucket(TokenBucketBase, SyncLuaScriptBase):
                     self.refill_amount,
                     self.initial_tokens or self.capacity,
                     self.refill_frequency,
-                    milliseconds,
                     self.expiry,
                     self.tokens_to_consume,
                 ],
@@ -104,8 +101,6 @@ class AsyncRedisTokenBucket(TokenBucketBase, AsyncLuaScriptBase):
 
     async def __aenter__(self) -> None:
         """Acquire token(s) from the token bucket and sleep until they are available."""
-        # Retrieve timestamp for when to wake up from Redis Lua script
-        milliseconds = get_current_time_ms()
         timestamp: int = cast(
             int,
             await self.script(
@@ -115,7 +110,6 @@ class AsyncRedisTokenBucket(TokenBucketBase, AsyncLuaScriptBase):
                     self.refill_amount,
                     self.initial_tokens or self.capacity,
                     self.refill_frequency,
-                    milliseconds,
                     self.expiry,
                     self.tokens_to_consume,
                 ],

--- a/src/steindamm/token_bucket/token_bucket.lua
+++ b/src/steindamm/token_bucket/token_bucket.lua
@@ -23,9 +23,8 @@ local capacity = tonumber(ARGV[1])
 local refill_amount = tonumber(ARGV[2])
 local initial_tokens = tonumber(ARGV[3])
 local time_between_slots = tonumber(ARGV[4]) * 1000 -- Convert to milliseconds
-local milliseconds = tonumber(ARGV[5])
-local expiry = tonumber(ARGV[6])
-local tokens_to_consume = tonumber(ARGV[7]) -- Number of tokens to consume
+local expiry = tonumber(ARGV[5])
+local tokens_to_consume = tonumber(ARGV[6]) -- Number of tokens to consume
 
 -- Validate that tokens_to_consume doesn't exceed capacity
 if tokens_to_consume > capacity then
@@ -40,8 +39,9 @@ end
 -- Keys
 local data_key = KEYS[1]
 
--- Get current time in milliseconds
-local now = milliseconds
+-- Get current time in milliseconds from Redis
+local time_parts = redis.call('TIME')
+local now = tonumber(time_parts[1]) * 1000 + math.floor(tonumber(time_parts[2]) / 1000)
 
 -- Default bucket values (used if no bucket exists yet)
 local tokens = math.min(initial_tokens, capacity)

--- a/src/steindamm/token_bucket/token_bucket_base.py
+++ b/src/steindamm/token_bucket/token_bucket_base.py
@@ -22,11 +22,6 @@ PositiveFloat = Annotated[float, Field(gt=0)]
 NonNegativeFloat = Annotated[float, Field(ge=0)]
 
 
-def get_current_time_ms() -> int:
-    """Get the current time in milliseconds."""
-    return int(time.time() * 1000)
-
-
 # Defaults are defined here and in Async/SyncTokenBucket to help with typehints - keep them in sync
 class TokenBucketBase(BaseModel):
     """Base class for Token Bucket rate limiters."""
@@ -112,7 +107,7 @@ class TokenBucketBase(BaseModel):
         if self.tokens_to_consume <= 0:
             raise ValueError("Must consume at least 1 token")
 
-        now = get_current_time_ms()
+        now = int(time.time() * 1000)
         time_between_slots = self.refill_frequency * 1000
 
         # Initialize bucket state (None for new buckets)

--- a/tests/semaphore/test_async_semaphore.py
+++ b/tests/semaphore/test_async_semaphore.py
@@ -19,6 +19,7 @@ from tests.conftest import (
     SemaphoreConfig,
     async_run,
     async_semaphore_factory,
+    initialize_async_connection,
 )
 
 logger = logging.getLogger(__name__)
@@ -49,9 +50,10 @@ async def test_semaphore_runtimes(
     a Semaphore with a capacity of 5, where each instance sleeps 1 second, then it should
     always take 1 >= seconds to run those.
     """
-    connection = connection_factory()
+    connection = await initialize_async_connection(connection_factory())
     if connection is None:  # TODO: Add support for in-memory semaphore
         pytest.skip("In-memory connection does not support semaphore")
+
     config = SemaphoreConfig(capacity=capacity)
     tasks = [
         asyncio.create_task(

--- a/tests/token_bucket/test_async_token_bucket.py
+++ b/tests/token_bucket/test_async_token_bucket.py
@@ -18,6 +18,7 @@ from tests.conftest import (
     MockTokenBucketConfig,
     async_run,
     async_tokenbucket_factory,
+    initialize_async_connection,
 )
 
 logger = logging.getLogger(__name__)
@@ -37,8 +38,9 @@ async def test_token_bucket_runtimes(
     connection_factory: ConnectionFactory, n: int, frequency: float, timeout: int
 ) -> None:
     """Test that n requests complete in expected time based on refill frequency."""
+    connection = await initialize_async_connection(connection_factory())
     config = MockTokenBucketConfig(refill_frequency=frequency)
-    bucket = async_tokenbucket_factory(connection=connection_factory(), config=config)
+    bucket = async_tokenbucket_factory(connection=connection, config=config)
     # Ensure n tasks never complete in less than n/(refill_frequency * refill_amount)
     tasks = [
         asyncio.create_task(
@@ -100,8 +102,10 @@ async def test_high_concurrency_token_acquisition(
     connection_factory: ConnectionFactory,
 ) -> None:
     """Test many concurrent tasks accessing the same bucket."""
+    connection = await initialize_async_connection(connection_factory())
+
     bucket = async_tokenbucket_factory(
-        connection=connection_factory(),
+        connection=connection,
         config=MockTokenBucketConfig(capacity=5, refill_frequency=0.1, refill_amount=5),
     )
 
@@ -146,7 +150,8 @@ async def test_token_bucket_tokens_to_consume(  # noqa: PLR0913
     timeout: float,
 ) -> None:
     """Test that tokens_to_consume parameter correctly controls token consumption per request."""
-    connection = connection_factory()
+    connection = await initialize_async_connection(connection_factory())
+
     config = MockTokenBucketConfig(
         capacity=5.0,
         refill_frequency=refill_frequency,
@@ -208,8 +213,10 @@ async def test_initial_tokens(
     connection_factory: ConnectionFactory, initial_tokens: float | None, expected_value: float, expected_requests: int
 ) -> None:
     """Test that initial_tokens defaults to capacity or uses explicit value and affects behavior."""
+    connection = await initialize_async_connection(connection_factory())
+
     config = MockTokenBucketConfig(capacity=5, initial_tokens=initial_tokens)
-    bucket = async_tokenbucket_factory(connection=connection_factory(), config=config)
+    bucket = async_tokenbucket_factory(connection=connection, config=config)
 
     # Test the value is set correctly
     assert bucket.initial_tokens == expected_value


### PR DESCRIPTION
This will allow more accurate time control since the token is considered based on the local time on the Redis node instead of starting to count from the time when the client sent the token (this would also include things like latency).

The tests needed to be updated to now allow the async client establish the connection first and then consume tokens. Without this change tests were failing due to the time it took to establish the connection.